### PR TITLE
Fix xboard node reporting

### DIFF
--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -671,9 +671,9 @@ void XboardEngine::parseLine(const QString& line)
 		// Node count
 		if ((ref = nextToken(ref)).isNull())
 			return;
-		val = ref.toString().toULongLong(&ok);
+		unsigned long long node = ref.toString().toULongLong(&ok);
 		if (ok)
-			m_eval.setNodeCount(val);
+			m_eval.setNodeCount(node);
 
 		// Principal variation
 		if ((ref = nextToken(ref, true)).isNull())


### PR DESCRIPTION
Before this patch, the string is parsed as a 64-bit value then cast into an int before being converted back to unsigned 64-bit value. This makes node reporting bogus above 2^31-1 nodes (and therefore the speed too).

I'll also report to upstream.