### PR TITLE
Set option "Threads" first to speed up the rest of the engine init

### DIFF
--- a/projects/lib/src/chessengine.cpp
+++ b/projects/lib/src/chessengine.cpp
@@ -235,6 +235,10 @@ void ChessEngine::start()
 
 void ChessEngine::onProtocolStart()
 {
+	const char *uciOptionThreads = "Threads";
+	const char *xboardOptionThreads = "cores";
+	QMap<QString, QVariant>::const_iterator i;
+
 	m_protocolStartTimer->stop();
 	m_pinging = false;
 	setState(Idle);
@@ -242,10 +246,21 @@ void ChessEngine::onProtocolStart()
 
 	flushWriteBuffer();
 
-	QMap<QString, QVariant>::const_iterator i = m_optionBuffer.constBegin();
+	// We'll set the threads option before anything else. On many engines, this will speed up hash init
+	i = m_optionBuffer.constFind(uciOptionThreads);
+	if (i != m_optionBuffer.constEnd())
+		setOption(i.key(), i.value());
+
+	i = m_optionBuffer.constFind(xboardOptionThreads);
+	if (i != m_optionBuffer.constEnd())
+		setOption(i.key(), i.value());
+
+	i = m_optionBuffer.constBegin();
 	while (i != m_optionBuffer.constEnd())
 	{
-		setOption(i.key(), i.value());
+		if ((i.key() != uciOptionThreads) && (i.key() != xboardOptionThreads))
+			setOption(i.key(), i.value());
+
 		++i;
 	}
 	m_optionBuffer.clear();


### PR DESCRIPTION
I have tested this locally with Stockfish for UCI. The cutechess output log says that "Threads" is set first before anything else.

The Xboard stuff is pure guess-work at this stage based on http://home.hccnet.nl/h.g.muller/engine-intf.html . If the option name is incorrect, it's unlikely to cause any major issues, though.