### PR TITLE
Don't convert raw uci scores into mate scores

### DIFF
--- a/projects/cli/src/enginematch.cpp
+++ b/projects/cli/src/enginematch.cpp
@@ -1100,12 +1100,6 @@ void EngineMatch::onGameFinished(ChessGame* game, int number)
 					// Detect out-of-range scores
 					if (absScore > 99999)
 						sScore = score < 0 ? "-999.99" : "999.99";
-					else if (absScore > 9900	// Detect mate-in-n scores
-						&& (absScore = 1000 - (absScore % 1000)) < 100)
-					{
-						sScore = score < 0 ? "-" : "";
-						sScore += "M" + QString::number(absScore);
-					}
 					else
 						sScore = QString::number(double(score) / 100.0, 'f', 2);
 

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -48,18 +48,7 @@ QString ChessGame::evalString(const MoveEvaluation& eval, const Chess::Move& mov
 		{
 			int score = eval.score();
 			int absScore = qAbs(score);
-
-			// Detect mate-in-n scores
-			if (absScore > 9900
-			&&  (absScore = 1000 - (absScore % 1000)) < 100)
-			{
-				if (score < 0)
-					sScore = "-";
-				sScore += "M" + QString::number(absScore);
-			}
-			else
-				sScore = QString::number(double(score) / 100.0, 'f', 2);
-
+			sScore = QString::number(double(score) / 100.0, 'f', 2);
 		} else
 			sScore = "0.00";
 

--- a/projects/lib/src/moveevaluation.cpp
+++ b/projects/lib/src/moveevaluation.cpp
@@ -119,17 +119,7 @@ QString MoveEvaluation::scoreText() const
 		int absScore = qAbs(m_score);
 		if (m_score > 0)
 			str += "+";
-
-		// Detect mate-in-n scores
-		if (absScore > 98800
-		&&  (absScore = 1000 - (absScore % 1000)) < 200)
-		{
-			if (m_score < 0)
-				str += "-";
-			str += "M" + QString::number(absScore);
-		}
-		else
-			str += QString::number(double(m_score) / 100.0, 'f', 2);
+		str += QString::number(double(m_score) / 100.0, 'f', 2);
 	}
 
 	return str;


### PR DESCRIPTION
Often in TCEC chat, people are confused why an engine is reporting mate scores when there's no mate. This happens when the engine's cp score is within 100 less than a multiple of 1000; a long time ago some engines didn't report mate scores as "score mate x", and cutechess added this heuristic to guess that, e.g. a score of +99.87 really means M13.

However, basically all modern engines now report mate score directly using e.g. "score mate 13". With lots of recent engines like LCZero/AllieStein sometimes displaying high evals like +119.63 (which nonsensically gets translated to M37), false positives are much more frequent than true positives, causing lots of confusion and questions in TCEC chat. I propose we remove this now-outdated detection rule.