### PR TITLE
Remove time reduction in knockout tiebreaks

### DIFF
--- a/projects/lib/src/knockouttournament.cpp
+++ b/projects/lib/src/knockouttournament.cpp
@@ -203,46 +203,6 @@ void KnockoutTournament::setTC(TournamentPlayer white, TournamentPlayer black, C
 
 	qWarning() << "ARUN: Holy:" << white.builder()->resumescore();
 
-	if ((firstScore + secondScore) >= 32)
-	{
-		wTimeControl.setTimePerTc(60000);
-		wTimeControl.setTimeIncrement(1000);
-		bTimeControl.setTimePerTc(60000);
-		bTimeControl.setTimeIncrement(1000);
-		qWarning() << "ARUNN: reducing TC: 16" << white.timeControl().timePerTc();
-	}
-	else if ((firstScore + secondScore) >= 28)
-	{
-		wTimeControl.setTimePerTc(120000);
-		wTimeControl.setTimeIncrement(1000);
-		bTimeControl.setTimePerTc(120000);
-		bTimeControl.setTimeIncrement(1000);
-		qWarning() << "ARUNN: reducing TC: 14" << white.timeControl().timePerTc();
-	}
-	else if ((firstScore + secondScore) >= 24)
-	{
-		wTimeControl.setTimePerTc(240000);
-		wTimeControl.setTimeIncrement(2000);
-		bTimeControl.setTimePerTc(240000);
-		bTimeControl.setTimeIncrement(2000);
-		qWarning() << "ARUNN: reducing TC: 12" << white.timeControl().timePerTc();
-	}
-	else if ((firstScore + secondScore) >= 20)
-	{
-		wTimeControl.setTimePerTc(480000);
-		wTimeControl.setTimeIncrement(3000);
-		bTimeControl.setTimePerTc(480000);
-		bTimeControl.setTimeIncrement(3000);
-		qWarning() << "ARUNN: reducing TC: 10" << white.timeControl().timePerTc();
-	}
-	else if ((firstScore + secondScore) >= 16)
-	{
-		wTimeControl.setTimePerTc(960000);
-		bTimeControl.setTimePerTc(960000);
-		wTimeControl.setTimeIncrement(4000);
-		bTimeControl.setTimeIncrement(4000);
-		qWarning() << "ARUNN: reducing TC: 8" << white.timeControl().timePerTc();
-	}
 	game->setTimeControl(wTimeControl, Chess::Side::White);
 	game->setTimeControl(bTimeControl, Chess::Side::Black);
 }


### PR DESCRIPTION
Cup 5 and earlier had reduced time when tiebreaks had gone enough long. Removed code because Cup 6 does not have TC changes.