### PR TITLE
Send rating difference between player and opponent (UCI)

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -86,6 +86,7 @@ UciEngine::UciEngine(QObject* parent)
 	: ChessEngine(parent),
 	  m_useDirectPv(false),
 	  m_sendOpponentsName(false),
+	  m_sendRatingAdv(false),
 	  m_canPonder(false),
 	  m_ponderState(NotPondering),
 	  m_movesPondered(0),
@@ -159,6 +160,12 @@ void UciEngine::startGame()
 		QString value = QString("none %1 %2 %3")
 				.arg(opRating, opType, opponent()->name());
 		sendOption("UCI_Opponent", value);
+        }
+
+	if (m_sendRatingAdv)
+	{
+		if (opponent()->rating() && rating())
+			sendOption("UCI_RatingAdv", QString::number(rating() - opponent()->rating()));
 	}
 
 	sendPosition();
@@ -768,6 +775,8 @@ void UciEngine::parseLine(const QString& line)
 			addVariantsFromOption(option);
 		else if (option->name() == "UCI_Opponent")
 			m_sendOpponentsName = true;
+		else if (option->name() == "UCI_RatingAdv")
+			m_sendRatingAdv = true;
 		else if (option->name() == "Ponder")
 			m_canPonder = true;
 		else

--- a/projects/lib/src/uciengine.h
+++ b/projects/lib/src/uciengine.h
@@ -90,6 +90,7 @@ class LIB_EXPORT UciEngine : public ChessEngine
 		// after it sends a "bestmove"
 		QStringList m_bmBuffer;
 		bool m_sendOpponentsName;
+		bool m_sendRatingAdv;
 		bool m_canPonder;
 		PonderState m_ponderState;
 		Chess::Move m_ponderMove;


### PR DESCRIPTION
Send "UCI_RatingAdv" to communicate the rating difference between the
player and the opponent. The difference is computed as the rating
advantage. That is:

  UCI_RatingAdv = OwnRating - OpponentRating

UCI_RatingAdv can be used for contempt based on the relative opponent
strength, for instance.

UCI_RatingAdv is sent only when the ratings for both engines are
defined.