### PR TITLE
Fix false matescores

### DIFF
--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -50,8 +50,8 @@ QString ChessGame::evalString(const MoveEvaluation& eval, const Chess::Move& mov
 			int absScore = qAbs(score);
 
 			// Detect mate-in-n scores
-			if (absScore > 9900
-			&&  (absScore = 1000 - (absScore % 1000)) < 100)
+			if (absScore > 98800
+			&&  (absScore = 1000 - (absScore % 1000)) < 200)
 			{
 				if (score < 0)
 					sScore = "-";


### PR DESCRIPTION
Apparently the final piece of https://github.com/cutechess/cutechess/pull/253

The duplicate code in [moveevaluation.cpp](https://github.com/TCEC-Chess/tceccutechess/blob/master/projects/lib/src/moveevaluation.cpp#L123) already uses the newer value.
So does [uciengine.cpp](https://github.com/TCEC-Chess/tceccutechess/blob/master/projects/lib/src/uciengine.cpp#L440) 
And [xboardengine](https://github.com/TCEC-Chess/tceccutechess/blob/master/projects/lib/src/xboardengine.cpp#L569) already has the entire function

Untested